### PR TITLE
Chart fix

### DIFF
--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -229,25 +229,20 @@ const DataBarChart = () => {
     }
   ]
 
-  if (!barChartData || barChartData.length === 0) {
-    return null
-  }
-  // const dataObj = getLastYearOrTwo(barChartData)
-  // const chartData = createChartData(dataObj).reverse()
-  console.log(createChartData(getLastYearOrTwo(mock)))
+  const dataObj = getLastYearOrTwo(barChartData)
+  const chartData = createChartData(dataObj).reverse()
   return (<div>
     <BarChart
       width={windowWidth > 500 ? 500 : 300}
       height={windowWidth > 500 ? 300 : 150}
-      data={mockData}
+      data={chartData}
       style={{ margin: '0 auto' }}
     >
       <CartesianGrid strokeDasharray="3 3" />
       <XAxis dataKey={windowWidth > 500 ? "name" : "mobileName"} />
-      <YAxis />
+      <YAxis allowDecimals={false} type="number" />
       <Tooltip />
       <Legend />
-      {/*<Bar dataKey="pv" fill="#8884d8" />*/}
       <Bar dataKey="uv" fill="#82ca9d" name={'Liczba zarejestrowanych użytkowników'} />
     </BarChart>
   </div>

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -114,9 +114,10 @@ const DataBarChart = () => {
       return processChartDataToRenderableObject(lastTwoMonths)
     }
     else if (typeof array !== 'undefined' && array.length > 1) {
-      const prevYear = latestYearData.year - 1
-      const latestYear = latestYearData.year
-      const prevYear2 = array.reduce((acc, current)=>(current.year < latestYear  && current.year > acc ))
+      const lastYear = latestYearData.year
+      const prevYearsArr = array.filter(data => data.year !== lastYear)
+      const prevYearData = prevYearsArr.reduce((acc, current)=>((current.year > acc ? current: acc)))
+      const prevYear = prevYearData.year
       if (prevYear && array) {
         const prevYearObj = array.find(userData => userData.year === prevYear)
         const lastMonth = sortedByMonthsDESC(prevYearObj.data)[0]

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -103,6 +103,74 @@ const DataBarChart = () => {
       }
     ))
   }
+
+  const mock = [
+    {
+      a: "4qeUoEWmtyVSJfvwf7KKj4K6qB43",
+      date: {
+        month: { name: "September", value: 8 },
+        year: 2020,
+      },
+      email: "super@super.super",
+      name: "KontoZPazdziernika"
+    },
+    {
+      a: "33333",
+      date: {
+        month: { name: "September", value: 8 },
+        year: 2020,
+      },
+      email: "fake@fake",
+      name: "KontoZWrzesnia"
+    },
+    {
+      a: "32323232323",
+      date: {
+        month: { name: "September", value: 8 },
+        year: 2020,
+      },
+      email: "fake@fake",
+      name: "KontoZWrzesnia2"
+    },
+    {
+      a: "2222222",
+      date: {
+        month: { name: "August", value: 7 },
+        year: 2019,
+      },
+      email: "August@fake",
+      name: "KontoZAugustowa"
+    },
+    {
+      a: "33333",
+      date: {
+        month: { name: "August", value: 7 },
+        year: 2019,
+      },
+      email: "August@fake",
+      name: "KontoZAugustowa"
+    },
+    {
+      a: "4444",
+      date: {
+        month: { name: "July", value: 6 },
+        year: 2019,
+      },
+      email: "july@fake",
+      name: "KontoZJulyowa"
+    },
+    {
+      a: "33333",
+      date: {
+        month: { name: "August", value: 7 },
+        year: 2018,
+      },
+      email: "2018@fake",
+      name: "20182018"
+    },
+
+  ]
+
   const createChartData = (array) => {
     if (!array) return
     const latestYearData = array[0]
@@ -118,6 +186,7 @@ const DataBarChart = () => {
       const prevYearsArr = array.filter(data => data.year !== lastYear)
       const prevYearData = prevYearsArr.reduce((acc, current)=>((current.year > acc ? current: acc)))
       const prevYear = prevYearData.year
+      //TODO fix naming and remove condition
       if (prevYear && array) {
         const prevYearObj = array.find(userData => userData.year === prevYear)
         const lastMonth = sortedByMonthsDESC(prevYearObj.data)[0]
@@ -129,6 +198,8 @@ const DataBarChart = () => {
       }
     }
   }
+
+console.log(createChartData(getLastYearOrTwo(mock)))
 
   const dataObj = getLastYearOrTwo(barChartData)
   const chartData = createChartData(dataObj).reverse()

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -129,34 +129,59 @@ const DataBarChart = () => {
       },
     ]
   }
-  const sortedByMonths = (data) => data.sort((a, b) => a.date.value > b.date.value)
+  const sortedByMonthsDESC = (data) => data.sort((a, b) => a.date.value > b.date.value)
 
   const createChartData = (array) => {
+    const latestYearData = array[0]
     if (array.length === 1) {
-      const sorted = sortedByMonths(array[0].data)
+      const sorted = sortedByMonthsDESC(latestYearData.data)
       const latestMonthValue = sorted[0].date.month.value
       const prevMonthValue = sorted.find(userData => userData.date.month.value < latestMonthValue).date.month.value
       const lastTwoMonths = sorted.filter(userData => userData.date.month.value === latestMonthValue || userData.date.month.value === prevMonthValue)
-      console.log(lastTwoMonths)
+      const data = lastTwoMonths.reduce((acc, { date }) => {
+        const { name } = date.month
+        if (typeof acc[name] === 'undefined') {
+          acc[name] = 1
+        }
+        else {
+          acc[name] += 1
+        }
+        return acc
+      }, {})
+      const res = Object.entries(data).map(([name,value]) => ({name, value}))
+      return res.map(({name, value}) => (
+        {
+          name,
+          uv: value,
+          pv: value,
+          amt: value,
+        }
+      ))
 
       // find previous month 
       // prepare them as chart data
 
     }
     if (array.length < 1) {
-      const latestMonthValueFromPrevYear = sortedByMonths(array[1].data)[0].date.month.value
-      console.log(latestMonthValueFromPrevYear)
+      const prevYear = latestYearData.year - 1
+      const prevYearData = array.find(userData => userData.date.year === prevYear)
+      const lastMonth = sortedByMonthsDESC(prevYearData)[0]
+
+      console.log(lastMonth)
 
     }
   }
+  const dataObj = getLastYearOrTwo(mock)
 
+  const chartData = createChartData(dataObj)
+  console.log(chartData)
 
   const mockData = [
 
     {
       name: 'Listopad',
       mobileName: '08',
-      uv: 2,
+      uv: 1,
       pv: 2,
       amt: 2,
     },
@@ -169,11 +194,6 @@ const DataBarChart = () => {
     }
   ]
   // if (!barChartData) return null
-  // console.log(getLastYearOrTwo(mock))
-  const dataObj = getLastYearOrTwo(mock)
-  console.log(dataObj)
-  createChartData(dataObj)
-
 
   return (<div>
     <BarChart

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -27,11 +27,13 @@ const DataBarChart = () => {
     // eslint-disable-next-line
   }, [])
 
-  const getMonthName = (num) => {
+  const getMonth = (num) => {
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    if (typeof num === 'string'){
+      return months.indexOf(num)
+    }
     return months[num]
   }
-
 
   const mock = [
     {
@@ -108,7 +110,7 @@ const DataBarChart = () => {
         ...current,
         date: {
           month: {
-            name: getMonthName(dateFromTimestamp.getMonth()),
+            name: getMonth(dateFromTimestamp.getMonth()),
             value,
           },
           year: dateFromTimestamp.getFullYear()

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -104,73 +104,6 @@ const DataBarChart = () => {
     ))
   }
 
-  const mock = [
-    {
-      a: "4qeUoEWmtyVSJfvwf7KKj4K6qB43",
-      date: {
-        month: { name: "September", value: 8 },
-        year: 2020,
-      },
-      email: "super@super.super",
-      name: "KontoZPazdziernika"
-    },
-    {
-      a: "33333",
-      date: {
-        month: { name: "September", value: 8 },
-        year: 2020,
-      },
-      email: "fake@fake",
-      name: "KontoZWrzesnia"
-    },
-    {
-      a: "32323232323",
-      date: {
-        month: { name: "September", value: 8 },
-        year: 2020,
-      },
-      email: "fake@fake",
-      name: "KontoZWrzesnia2"
-    },
-    {
-      a: "2222222",
-      date: {
-        month: { name: "August", value: 7 },
-        year: 2019,
-      },
-      email: "August@fake",
-      name: "KontoZAugustowa"
-    },
-    {
-      a: "33333",
-      date: {
-        month: { name: "August", value: 7 },
-        year: 2019,
-      },
-      email: "August@fake",
-      name: "KontoZAugustowa"
-    },
-    {
-      a: "4444",
-      date: {
-        month: { name: "July", value: 6 },
-        year: 2019,
-      },
-      email: "july@fake",
-      name: "KontoZJulyowa"
-    },
-    {
-      a: "33333",
-      date: {
-        month: { name: "August", value: 7 },
-        year: 2018,
-      },
-      email: "2018@fake",
-      name: "20182018"
-    },
-
-  ]
-
   const createChartData = (array) => {
     if (!array) return
     const latestYearData = array[0]
@@ -193,8 +126,6 @@ const DataBarChart = () => {
       return processChartDataToRenderableObject(lastTwoMonths)
     }
   }
-
-  console.log(createChartData(getLastYearOrTwo(mock)))
 
   const dataObj = getLastYearOrTwo(barChartData)
   const chartData = createChartData(dataObj).reverse()

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -131,12 +131,22 @@ const DataBarChart = () => {
   }
   const sortedByMonths = (data) => data.sort((a, b) => a.date.value > b.date.value)
 
-  const createChartData = (array)=> {
-    if(array.length === 1) {
-      const latestMonthValue = sortedByMonths(array[0].data)[0].date.month.value
+  const createChartData = (array) => {
+    if (array.length === 1) {
+      const sorted = sortedByMonths(array[0].data)
+      const latestMonthValue = sorted[0].date.month.value
+      const prevMonthValue = sorted.find(userData => userData.date.month.value < latestMonthValue).date.month.value
+      const lastTwoMonths = sorted.filter(userData => userData.date.month.value === latestMonthValue || userData.date.month.value === prevMonthValue)
+      console.log(lastTwoMonths)
+
       // find previous month 
       // prepare them as chart data
-      
+
+    }
+    if (array.length < 1) {
+      const latestMonthValueFromPrevYear = sortedByMonths(array[1].data)[0].date.month.value
+      console.log(latestMonthValueFromPrevYear)
+
     }
   }
 

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -19,8 +19,6 @@ const DataBarChart = () => {
       const result = await fetchUsers()
       const usersWithDate = result.filter(user => user.date)
       const usersWithProcessedDate = setUsersDateObject(usersWithDate)
-      // const data = getLastYearOrTwo(usersWithProcessedDate)
-      // const chartData = createChartData(mock)
       setBarchartData(usersWithProcessedDate)
     }
     f()

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -8,6 +8,7 @@ import {
   Tooltip,
   Legend,
 } from 'recharts';
+import { date } from 'yup';
 import { fetchUsers } from "../services/TripService";
 
 const windowWidth = window.screen.width;
@@ -17,11 +18,35 @@ const DataBarChart = () => {
   useEffect(() => {
     const f = async () => {
       const result = await fetchUsers()
-      setBarchartData(result)
+      const usersWithDate = result.filter(user => user.date)
+      const usersWithProcessedDate = setUsersDateObject(usersWithDate)
+      setBarchartData(usersWithProcessedDate)
     }
     f()
     // eslint-disable-next-line
-  }, [])
+  },[])
+
+  const getMonthName = (num) => {
+    const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+    return months[num - 1]
+  }
+
+  const setUsersDateObject = (user) => (user.reduce((acc, current) => {
+    const dateFromTimestamp = new Date(current.date)
+    const value = dateFromTimestamp.getMonth()
+    return [
+      ...acc, {
+        ...current,
+        date: {
+          month: {
+            name: getMonthName(dateFromTimestamp.getMonth()),
+            value,
+          },
+          year: dateFromTimestamp.getFullYear()
+        }
+      }
+    ]
+  }, []))
 
   const mockData = [
 

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -29,7 +29,7 @@ const DataBarChart = () => {
 
   const getMonth = (num) => {
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-    if (typeof num === 'string'){
+    if (typeof num === 'string') {
       return months.indexOf(num)
     }
     return months[num]
@@ -118,6 +118,11 @@ const DataBarChart = () => {
       }
     ]
   }, []))
+
+  if (!barChartData || barChartData.length === 0) {
+    return null
+  }
+
   const getLastYearOrTwo = (users) => {
     if (users.length < 1) return
     const lastRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
@@ -132,7 +137,6 @@ const DataBarChart = () => {
         }
       ]
     }
-
     return [
       {
         year: lastRegisterYear,
@@ -174,20 +178,37 @@ const DataBarChart = () => {
         }
       ))
     }
-    else if (typeof array !== 'undefined' && array.length > 1 ) {
+    else if (typeof array !== 'undefined' && array.length > 1) {
       const prevYear = latestYearData.year - 1
       if (prevYear && array) {
-        // console.log(array)
         const prevYearObj = array.find(userData => userData.year === prevYear)
         const lastMonth = sortedByMonthsDESC(prevYearObj.data)[0]
         const lastMonthValue = lastMonth.date.month.value
         const prevYearData = prevYearObj.data.filter(userData => userData.date.month.value === lastMonthValue)
-        console.log(prevYearData)
+        const currentYearData = latestYearData.data
+        const lastTwoMonths = [...currentYearData, ...prevYearData]
+        const data = lastTwoMonths.reduce((acc, { date }) => {
+          const { name } = date.month
+          if (typeof acc[name] === 'undefined') {
+            acc[name] = 1
+          }
+          else {
+            acc[name] += 1
+          }
+          return acc
+        }, {})
+        const res = Object.entries(data).map(([name, value]) => ({ name, value }))
+
+        return res.map(({ name, value }) => (
+          {
+            name,
+            uv: value,
+            pv: value,
+            amt: value,
+          }
+        ))
       }
     }
-    // else {
-    // console.error('wrong data specified', array)
-    // }
   }
 
   const mockData = [

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -83,7 +83,7 @@ const DataBarChart = () => {
 
   const processChartDataToRenderableObject = (data) => {
     const countedMonths = data.reduce((acc, { date }) => {
-      const { month: {name} } = date
+      const { month: { name } } = date
       if (typeof acc[name] === 'undefined') {
         acc[name] = 1
       }
@@ -184,22 +184,17 @@ const DataBarChart = () => {
     else if (typeof array !== 'undefined' && array.length > 1) {
       const lastYear = latestYearData.year
       const prevYearsArr = array.filter(data => data.year !== lastYear)
-      const prevYearData = prevYearsArr.reduce((acc, current)=>((current.year > acc ? current: acc)))
-      const prevYear = prevYearData.year
-      //TODO fix naming and remove condition
-      if (prevYear && array) {
-        const prevYearObj = array.find(userData => userData.year === prevYear)
-        const lastMonth = sortedByMonthsDESC(prevYearObj.data)[0]
-        const lastMonthValue = lastMonth.date.month.value
-        const prevYearData = prevYearObj.data.filter(userData => userData.date.month.value === lastMonthValue)
-        const currentYearData = latestYearData.data
-        const lastTwoMonths = [...currentYearData, ...prevYearData]
-        return processChartDataToRenderableObject(lastTwoMonths)
-      }
+      const prevYearData = prevYearsArr.reduce((acc, current) => ((current.year > acc ? current : acc)))
+      const lastMonth = sortedByMonthsDESC(prevYearData.data)[0]
+      const lastMonthValue = lastMonth.date.month.value
+      const lastMonthFromprevYearData = prevYearData.data.filter(userData => userData.date.month.value === lastMonthValue)
+      const currentYearData = latestYearData.data
+      const lastTwoMonths = [...currentYearData, ...lastMonthFromprevYearData]
+      return processChartDataToRenderableObject(lastTwoMonths)
     }
   }
 
-console.log(createChartData(getLastYearOrTwo(mock)))
+  console.log(createChartData(getLastYearOrTwo(mock)))
 
   const dataObj = getLastYearOrTwo(barChartData)
   const chartData = createChartData(dataObj).reverse()

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -8,7 +8,6 @@ import {
   Tooltip,
   Legend,
 } from 'recharts';
-import { date } from 'yup';
 import { fetchUsers } from "../services/TripService";
 
 const windowWidth = window.screen.width;
@@ -24,12 +23,71 @@ const DataBarChart = () => {
     }
     f()
     // eslint-disable-next-line
-  },[])
+  }, [])
 
   const getMonthName = (num) => {
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
-    return months[num - 1]
+    return months[num]
   }
+
+
+  const mock = [
+    {
+      a: "4qeUoEWmtyVSJfvwf7KKj4K6qB43",
+      date: {
+        month: { name: "October", value: 9 },
+        year: 2020,
+      },
+      email: "super@super.super",
+      name: "KontoZPazdziernika"
+    },
+    {
+      a: "33333",
+      date: {
+        month: { name: "September", value: 8 },
+        year: 2020,
+      },
+      email: "fake@fake",
+      name: "KontoZWrzesnia"
+    },
+    {
+      a: "32323232323",
+      date: {
+        month: { name: "September", value: 8 },
+        year: 2020,
+      },
+      email: "fake@fake",
+      name: "KontoZWrzesnia2"
+    },
+    {
+      a: "2222222",
+      date: {
+        month: { name: "August", value: 7 },
+        year: 2019,
+      },
+      email: "August@fake",
+      name: "KontoZAugustowa"
+    },
+    {
+      a: "33333",
+      date: {
+        month: { name: "August", value: 7 },
+        year: 2019,
+      },
+      email: "August@fake",
+      name: "KontoZAugustowa"
+    },
+    {
+      a: "33333",
+      date: {
+        month: { name: "August", value: 7 },
+        year: 2018,
+      },
+      email: "2018@fake",
+      name: "20182018"
+    },
+
+  ]
 
   const setUsersDateObject = (user) => (user.reduce((acc, current) => {
     const dateFromTimestamp = new Date(current.date)
@@ -47,6 +105,21 @@ const DataBarChart = () => {
       }
     ]
   }, []))
+  const getLastTwoYears = (users) => {
+    const latestRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
+    return [
+      {
+        year: latestRegisterYear,
+        data: users.filter(user => user.date.year === latestRegisterYear)
+      },
+      {
+        year: latestRegisterYear - 1,
+        data: users.filter(user => user.date.year === latestRegisterYear - 1)
+      },
+    ]
+  }
+
+  const sortedByMonths = mock.sort((a, b) => a.date.value > b.date.value)
 
   const mockData = [
 
@@ -65,6 +138,8 @@ const DataBarChart = () => {
       amt: 2000,
     }
   ]
+  if (!barChartData) return null
+  console.log(getLastTwoYears(mock))
 
   return (<div>
     <BarChart

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -17,7 +17,7 @@ const DataBarChart = () => {
   useEffect(() => {
     const f = async () => {
       const result = await fetchUsers()
-      const usersWithDate = result.filter(user => user.date)
+      const usersWithDate = result.filter(({date}) => date)
       const usersWithProcessedDate = setUsersDateObject(usersWithDate)
       setBarchartData(usersWithProcessedDate)
     }
@@ -25,7 +25,7 @@ const DataBarChart = () => {
     // eslint-disable-next-line
   }, [])
 
-  const getMonth = (num) => {
+  const convertMonth = (num) => {
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
     if (typeof num === 'string') {
       return months.indexOf(num)
@@ -41,7 +41,7 @@ const DataBarChart = () => {
         ...current,
         date: {
           month: {
-            name: getMonth(dateFromTimestamp.getMonth()),
+            name: convertMonth(value),
             value,
           },
           year: dateFromTimestamp.getFullYear()

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -59,7 +59,6 @@ const DataBarChart = () => {
     const lastRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
     const lastYear = users.filter(user => user.date.year === lastRegisterYear)
     const hasUniqueMonths = lastYear.find((user, idx) => idx > 0 && user.date.month.value !== lastYear[0].date.month.value)
-    console.log(hasUniqueMonths)
     if (hasUniqueMonths) {
       return [
         {
@@ -81,6 +80,29 @@ const DataBarChart = () => {
   }
   const sortedByMonthsDESC = (data) => data.sort((a, b) => a.date.value > b.date.value)
 
+
+  const processChartDataToRenderableObject = (data) => {
+    const countedMonths = data.reduce((acc, { date }) => {
+      const { month: {name} } = date
+      if (typeof acc[name] === 'undefined') {
+        acc[name] = 1
+      }
+      else {
+        acc[name] += 1
+      }
+      return acc
+    }, {})
+    const res = Object.entries(countedMonths).map(([name, value]) => ({ name, value }))
+
+    return res.map(({ name, value }) => (
+      {
+        name,
+        uv: value,
+        pv: value,
+        amt: value,
+      }
+    ))
+  }
   const createChartData = (array) => {
     if (!array) return
     const latestYearData = array[0]
@@ -89,28 +111,12 @@ const DataBarChart = () => {
       const latestMonthValue = sorted[0].date.month.value
       const prevMonthValue = sorted.find(userData => userData.date.month.value < latestMonthValue).date.month.value
       const lastTwoMonths = sorted.filter(userData => userData.date.month.value === latestMonthValue || userData.date.month.value === prevMonthValue)
-      const data = lastTwoMonths.reduce((acc, { date }) => {
-        const { name } = date.month
-        if (typeof acc[name] === 'undefined') {
-          acc[name] = 1
-        }
-        else {
-          acc[name] += 1
-        }
-        return acc
-      }, {})
-      const res = Object.entries(data).map(([name, value]) => ({ name, value }))
-      return res.map(({ name, value }) => (
-        {
-          name,
-          uv: value,
-          pv: value,
-          amt: value,
-        }
-      ))
+      return processChartDataToRenderableObject(lastTwoMonths)
     }
     else if (typeof array !== 'undefined' && array.length > 1) {
       const prevYear = latestYearData.year - 1
+      const latestYear = latestYearData.year
+      const prevYear2 = array.reduce((acc, current)=>(current.year < latestYear  && current.year > acc ))
       if (prevYear && array) {
         const prevYearObj = array.find(userData => userData.year === prevYear)
         const lastMonth = sortedByMonthsDESC(prevYearObj.data)[0]
@@ -118,26 +124,7 @@ const DataBarChart = () => {
         const prevYearData = prevYearObj.data.filter(userData => userData.date.month.value === lastMonthValue)
         const currentYearData = latestYearData.data
         const lastTwoMonths = [...currentYearData, ...prevYearData]
-        const data = lastTwoMonths.reduce((acc, { date }) => {
-          const { name } = date.month
-          if (typeof acc[name] === 'undefined') {
-            acc[name] = 1
-          }
-          else {
-            acc[name] += 1
-          }
-          return acc
-        }, {})
-        const res = Object.entries(data).map(([name, value]) => ({ name, value }))
-
-        return res.map(({ name, value }) => (
-          {
-            name,
-            uv: value,
-            pv: value,
-            amt: value,
-          }
-        ))
+        return processChartDataToRenderableObject(lastTwoMonths)
       }
     }
   }

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -19,8 +19,8 @@ const DataBarChart = () => {
       const result = await fetchUsers()
       const usersWithDate = result.filter(user => user.date)
       const usersWithProcessedDate = setUsersDateObject(usersWithDate)
-      const data = getLastYearOrTwo(usersWithProcessedDate)
-      const chartData = createChartData(mock)
+      // const data = getLastYearOrTwo(usersWithProcessedDate)
+      // const chartData = createChartData(mock)
       setBarchartData(usersWithProcessedDate)
     }
     f()
@@ -37,7 +37,7 @@ const DataBarChart = () => {
     {
       a: "4qeUoEWmtyVSJfvwf7KKj4K6qB43",
       date: {
-        month: { name: "October", value: 8 },
+        month: { name: "September", value: 8 },
         year: 2020,
       },
       email: "super@super.super",
@@ -120,7 +120,8 @@ const DataBarChart = () => {
     if (users.length < 1) return
     const lastRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
     const lastYear = users.filter(user => user.date.year === lastRegisterYear)
-    const hasUniqueMonths = lastYear.find(user => user.date.month.value !== lastYear[0].date.month.value)
+    const hasUniqueMonths = lastYear.find((user, idx) => idx > 0 && user.date.month.value !== lastYear[0].date.month.value)
+    console.log(hasUniqueMonths)
     if (hasUniqueMonths) {
       return [
         {
@@ -208,14 +209,14 @@ const DataBarChart = () => {
   if (!barChartData || barChartData.length === 0) {
     return null
   }
-  const dataObj = getLastYearOrTwo(barChartData)
-  const chartData = createChartData(dataObj).reverse()
+  // const dataObj = getLastYearOrTwo(barChartData)
+  // const chartData = createChartData(dataObj).reverse()
   console.log(createChartData(getLastYearOrTwo(mock)))
   return (<div>
     <BarChart
       width={windowWidth > 500 ? 500 : 300}
       height={windowWidth > 500 ? 300 : 150}
-      data={chartData}
+      data={mockData}
       style={{ margin: '0 auto' }}
     >
       <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -19,6 +19,8 @@ const DataBarChart = () => {
       const result = await fetchUsers()
       const usersWithDate = result.filter(user => user.date)
       const usersWithProcessedDate = setUsersDateObject(usersWithDate)
+      const data = getLastYearOrTwo(usersWithProcessedDate)
+      const chartData = createChartData(mock)
       setBarchartData(usersWithProcessedDate)
     }
     f()
@@ -35,7 +37,7 @@ const DataBarChart = () => {
     {
       a: "4qeUoEWmtyVSJfvwf7KKj4K6qB43",
       date: {
-        month: { name: "October", value: 9 },
+        month: { name: "October", value: 8 },
         year: 2020,
       },
       email: "super@super.super",
@@ -78,6 +80,15 @@ const DataBarChart = () => {
       name: "KontoZAugustowa"
     },
     {
+      a: "4444",
+      date: {
+        month: { name: "July", value: 6 },
+        year: 2019,
+      },
+      email: "july@fake",
+      name: "KontoZJulyowa"
+    },
+    {
       a: "33333",
       date: {
         month: { name: "August", value: 7 },
@@ -106,6 +117,7 @@ const DataBarChart = () => {
     ]
   }, []))
   const getLastYearOrTwo = (users) => {
+    if (users.length < 1) return
     const lastRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
     const lastYear = users.filter(user => user.date.year === lastRegisterYear)
     const hasUniqueMonths = lastYear.find(user => user.date.month.value !== lastYear[0].date.month.value)
@@ -132,6 +144,7 @@ const DataBarChart = () => {
   const sortedByMonthsDESC = (data) => data.sort((a, b) => a.date.value > b.date.value)
 
   const createChartData = (array) => {
+    if (!array) return
     const latestYearData = array[0]
     if (array.length === 1) {
       const sorted = sortedByMonthsDESC(latestYearData.data)
@@ -148,8 +161,8 @@ const DataBarChart = () => {
         }
         return acc
       }, {})
-      const res = Object.entries(data).map(([name,value]) => ({name, value}))
-      return res.map(({name, value}) => (
+      const res = Object.entries(data).map(([name, value]) => ({ name, value }))
+      return res.map(({ name, value }) => (
         {
           name,
           uv: value,
@@ -157,24 +170,22 @@ const DataBarChart = () => {
           amt: value,
         }
       ))
-
-      // find previous month 
-      // prepare them as chart data
-
     }
-    if (array.length < 1) {
+    else if (typeof array !== 'undefined' && array.length > 1 ) {
       const prevYear = latestYearData.year - 1
-      const prevYearData = array.find(userData => userData.date.year === prevYear)
-      const lastMonth = sortedByMonthsDESC(prevYearData)[0]
-
-      console.log(lastMonth)
-
+      if (prevYear && array) {
+        // console.log(array)
+        const prevYearObj = array.find(userData => userData.year === prevYear)
+        const lastMonth = sortedByMonthsDESC(prevYearObj.data)[0]
+        const lastMonthValue = lastMonth.date.month.value
+        const prevYearData = prevYearObj.data.filter(userData => userData.date.month.value === lastMonthValue)
+        console.log(prevYearData)
+      }
     }
+    // else {
+    // console.error('wrong data specified', array)
+    // }
   }
-  const dataObj = getLastYearOrTwo(mock)
-
-  const chartData = createChartData(dataObj)
-  console.log(chartData)
 
   const mockData = [
 
@@ -193,13 +204,18 @@ const DataBarChart = () => {
       amt: 2000,
     }
   ]
-  // if (!barChartData) return null
 
+  if (!barChartData || barChartData.length === 0) {
+    return null
+  }
+  const dataObj = getLastYearOrTwo(barChartData)
+  const chartData = createChartData(dataObj).reverse()
+  console.log(createChartData(getLastYearOrTwo(mock)))
   return (<div>
     <BarChart
       width={windowWidth > 500 ? 500 : 300}
       height={windowWidth > 500 ? 300 : 150}
-      data={mockData}
+      data={chartData}
       style={{ margin: '0 auto' }}
     >
       <CartesianGrid strokeDasharray="3 3" />

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -105,16 +105,27 @@ const DataBarChart = () => {
       }
     ]
   }, []))
-  const getLastTwoYears = (users) => {
-    const latestRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
+  const getLastYearOrTwo = (users) => {
+    const lastRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
+    const lastYear = users.filter(user => user.date.year === lastRegisterYear)
+    const hasUniqueMonths = lastYear.find(user => user.date.month.value !== lastYear[0].date.month.value)
+    if (hasUniqueMonths && hasUniqueMonths.length > 1) {
+      return [
+        {
+          year: lastRegisterYear,
+          data: lastYear
+        }
+      ]
+    }
+
     return [
       {
-        year: latestRegisterYear,
-        data: users.filter(user => user.date.year === latestRegisterYear)
+        year: lastRegisterYear,
+        data: lastYear
       },
       {
-        year: latestRegisterYear - 1,
-        data: users.filter(user => user.date.year === latestRegisterYear - 1)
+        year: lastRegisterYear - 1,
+        data: users.filter(user => user.date.year === lastRegisterYear - 1)
       },
     ]
   }
@@ -139,7 +150,7 @@ const DataBarChart = () => {
     }
   ]
   if (!barChartData) return null
-  console.log(getLastTwoYears(mock))
+  console.log(getLastYearOrTwo(mock))
 
   return (<div>
     <BarChart

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -109,7 +109,7 @@ const DataBarChart = () => {
     const lastRegisterYear = users.sort((a, b) => a.date.year > b.date.year)[0].date.year
     const lastYear = users.filter(user => user.date.year === lastRegisterYear)
     const hasUniqueMonths = lastYear.find(user => user.date.month.value !== lastYear[0].date.month.value)
-    if (hasUniqueMonths && hasUniqueMonths.length > 1) {
+    if (hasUniqueMonths) {
       return [
         {
           year: lastRegisterYear,
@@ -129,8 +129,17 @@ const DataBarChart = () => {
       },
     ]
   }
+  const sortedByMonths = (data) => data.sort((a, b) => a.date.value > b.date.value)
 
-  const sortedByMonths = mock.sort((a, b) => a.date.value > b.date.value)
+  const createChartData = (array)=> {
+    if(array.length === 1) {
+      const latestMonthValue = sortedByMonths(array[0].data)[0].date.month.value
+      // find previous month 
+      // prepare them as chart data
+      
+    }
+  }
+
 
   const mockData = [
 
@@ -149,8 +158,12 @@ const DataBarChart = () => {
       amt: 2000,
     }
   ]
-  if (!barChartData) return null
-  console.log(getLastYearOrTwo(mock))
+  // if (!barChartData) return null
+  // console.log(getLastYearOrTwo(mock))
+  const dataObj = getLastYearOrTwo(mock)
+  console.log(dataObj)
+  createChartData(dataObj)
+
 
   return (<div>
     <BarChart

--- a/src/components/DataChart.js
+++ b/src/components/DataChart.js
@@ -35,73 +35,6 @@ const DataBarChart = () => {
     return months[num]
   }
 
-  const mock = [
-    {
-      a: "4qeUoEWmtyVSJfvwf7KKj4K6qB43",
-      date: {
-        month: { name: "September", value: 8 },
-        year: 2020,
-      },
-      email: "super@super.super",
-      name: "KontoZPazdziernika"
-    },
-    {
-      a: "33333",
-      date: {
-        month: { name: "September", value: 8 },
-        year: 2020,
-      },
-      email: "fake@fake",
-      name: "KontoZWrzesnia"
-    },
-    {
-      a: "32323232323",
-      date: {
-        month: { name: "September", value: 8 },
-        year: 2020,
-      },
-      email: "fake@fake",
-      name: "KontoZWrzesnia2"
-    },
-    {
-      a: "2222222",
-      date: {
-        month: { name: "August", value: 7 },
-        year: 2019,
-      },
-      email: "August@fake",
-      name: "KontoZAugustowa"
-    },
-    {
-      a: "33333",
-      date: {
-        month: { name: "August", value: 7 },
-        year: 2019,
-      },
-      email: "August@fake",
-      name: "KontoZAugustowa"
-    },
-    {
-      a: "4444",
-      date: {
-        month: { name: "July", value: 6 },
-        year: 2019,
-      },
-      email: "july@fake",
-      name: "KontoZJulyowa"
-    },
-    {
-      a: "33333",
-      date: {
-        month: { name: "August", value: 7 },
-        year: 2018,
-      },
-      email: "2018@fake",
-      name: "20182018"
-    },
-
-  ]
-
   const setUsersDateObject = (user) => (user.reduce((acc, current) => {
     const dateFromTimestamp = new Date(current.date)
     const value = dateFromTimestamp.getMonth()
@@ -210,24 +143,6 @@ const DataBarChart = () => {
       }
     }
   }
-
-  const mockData = [
-
-    {
-      name: 'Listopad',
-      mobileName: '08',
-      uv: 1,
-      pv: 2,
-      amt: 2,
-    },
-    {
-      name: 'Grudzień',
-      mobileName: '10',
-      uv: barChartData.length,
-      pv: 3908,
-      amt: 2000,
-    }
-  ]
 
   const dataObj = getLastYearOrTwo(barChartData)
   const chartData = createChartData(dataObj).reverse()

--- a/src/components/PieChart.js
+++ b/src/components/PieChart.js
@@ -7,15 +7,6 @@ import {
 } from 'recharts';
 import { fetchTrips } from "../services/TripService";
 
-const data = [
-  { name: 'Azja', value: 423 },
-  { name: 'Europa', value: 313 },
-  { name: 'Ameryka', value: 241 },
-  { name: 'Afryka', value: 87 },
-  { name: 'Ameryka Południowa', value: 328 },
-  { name: 'Antarktyda', value: 56 },
-  { name: 'Australia', value: 81 }
-];
 const windowWidth = window.screen.width;
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#d37736', '#FF8042', '#ff3c42', '#764afe'];
 
@@ -30,7 +21,6 @@ const PieChartComponent = () => {
         return result;
       }, {})
       const trips = Object.entries(distribution).map(([name, value]) => ({ name, value }))
-
       setTripsData(trips)
     }
     f()
@@ -51,7 +41,7 @@ const PieChartComponent = () => {
         label
       >
         {
-          data.map((entry, index) => <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />)
+          tripsData.map((entry, index) => <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />)
         }
       </Pie>
       <Tooltip />


### PR DESCRIPTION
Stało się. Bar chart pokazuje faktyczne wartości. 
Closes #55 

- każdy zarejestrowany użytkownik dostaje timestamp w momencie rejestracji
- na tej podstawie pokazuję rejestracje z ostatnich dwóch miesięcy
- jeśli nie było rejestracji w poprzednim miesiącu pokazuje się ostatni miesiąc, kiedy była jakaś
- jeśli w nowym roku były rejestracje tylko w 1 miesiącu to obok pokazuje się ostatni miesiąc z ostatniego wcześniejszego roku kiedy były rejestracje
- przy powyższym case'ie brakuje jakiegoś oznaczenia z jakiego roku są te miesiące. Typu October "19, zgłoszę to jako oddzielne issue.